### PR TITLE
Make SQLite path configurable

### DIFF
--- a/env.config.ts
+++ b/env.config.ts
@@ -10,6 +10,10 @@ export default defineEnv({
       .describe(
         "Encryption key for sensitive data. Must be a 64-character hex string.",
       ),
+    SQLITE_PATH: z
+      .string()
+      .default("scheduler.db")
+      .describe("Filesystem path to the SQLite database"),
   },
   shared: {
     NODE_ENV: z.enum(["development", "production"]).default("development"),
@@ -25,5 +29,6 @@ export default defineEnv({
   envStrict: {
     NODE_ENV: process.env.NODE_ENV,
     ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
+    SQLITE_PATH: process.env.SQLITE_PATH,
   },
 });

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -4,6 +4,7 @@ import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 
 import * as schema from "./schema";
+import env from "@/env.config";
 
-const sqlite = new Database("scheduler.db");
+const sqlite = new Database(env.SQLITE_PATH);
 export const db = drizzle(sqlite, { schema });


### PR DESCRIPTION
## Summary
- allow overriding SQLite path via `SQLITE_PATH` env var
- wire up new variable in env config
- use `SQLITE_PATH` when opening the database

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Jest couldn't find ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_68698d9284fc8322b7b004a4011f467c