### PR TITLE
Use constant for ical product identifier

### DIFF
--- a/__tests__/caldav.test.ts
+++ b/__tests__/caldav.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { describe, it, expect, jest } from '@jest/globals';
 import { createCalDavProvider } from '@/providers/caldav';
+import { ICAL_PROD_ID } from '@/types/constants';
 import { type DAVClient } from 'tsdav';
 
 const client = {
@@ -32,7 +33,9 @@ describe('CalDav provider', () => {
     expect(call.iCalString).toContain(`LOCATION:${input.location}`);
     expect(call.iCalString).toContain(`DESCRIPTION:${input.description}`);
     expect(call.iCalString).toContain(`UID:${event.id}`);
-    expect(call.iCalString).toContain('PRODID:-//Your Company//Your Product//EN');
+    expect(call.iCalString).toContain(
+      `PRODID:-//${ICAL_PROD_ID.company}//${ICAL_PROD_ID.product}//EN`,
+    );
 
     expect(event.title).toBe(input.title);
     expect(event.location).toBe(input.location);

--- a/providers/caldav.ts
+++ b/providers/caldav.ts
@@ -4,7 +4,7 @@ import {
   type CalendarEvent,
   type CalendarEventInput,
 } from "@/schemas/calendar-event";
-import { DEFAULT_TIMEZONE } from "@/types/constants";
+import { DEFAULT_TIMEZONE, ICAL_PROD_ID } from "@/types/constants";
 import { formatISO, parseISO } from "date-fns";
 import { type DAVClient } from "tsdav";
 import ical from "ical-generator";
@@ -82,7 +82,7 @@ export function createCalDavProvider(client: DAVClient, calendarUrl: string) {
     const dtstamp = new Date();
     const dtstampIso = dtstamp.toISOString();
 
-    const calendar = ical({ prodId: { company: "Your Company", product: "Your Product" } });
+    const calendar = ical({ prodId: ICAL_PROD_ID });
     calendar.createEvent({
       id: uid,
       summary: validatedInput.title,

--- a/types/constants.ts
+++ b/types/constants.ts
@@ -1,5 +1,10 @@
 export const DEFAULT_TIMEZONE = "UTC" as const;
 
+export const ICAL_PROD_ID = {
+  company: "example.com",
+  product: "scheduler",
+} as const;
+
 export const PROVIDER_NAMES = {
   GOOGLE: "google",
   APPLE: "icloud",


### PR DESCRIPTION
## Summary
- add `ICAL_PROD_ID` constant
- use `ICAL_PROD_ID` when generating CalDAV events
- update CalDAV tests for new identifier

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68699c739a2883228f63b5af331929d9