### PR TITLE
Refactor ConnectionsClient

### DIFF
--- a/app/connections/capabilities-field.tsx
+++ b/app/connections/capabilities-field.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { Control } from "react-hook-form";
+
+import { CAPABILITY } from "@/types/constants";
+import type { ConnectionFormValues } from "./use-connection-form";
+
+interface CapabilitiesFieldProps {
+  control: Control<ConnectionFormValues>;
+}
+
+export default function CapabilitiesField({ control }: CapabilitiesFieldProps) {
+  return (
+    <FormField
+      control={control}
+      name="capabilities"
+      render={() => (
+        <FormItem>
+          <div className="mb-4">
+            <FormLabel className="text-base">Capabilities</FormLabel>
+            <FormDescription>
+              Select what this calendar connection can be used for
+            </FormDescription>
+          </div>
+          <FormField
+            control={control}
+            name="capabilities"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start space-y-0 space-x-3">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value?.includes(CAPABILITY.CONFLICT)}
+                    onCheckedChange={(checked) => {
+                      const updated = checked
+                        ? [...field.value, CAPABILITY.CONFLICT]
+                        : field.value?.filter((v) => v !== CAPABILITY.CONFLICT);
+                      field.onChange(updated);
+                    }}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Conflict Checking</FormLabel>
+                  <FormDescription>Booked time is blocked</FormDescription>
+                </div>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="capabilities"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start space-y-0 space-x-3">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value?.includes(CAPABILITY.AVAILABILITY)}
+                    onCheckedChange={(checked) => {
+                      const updated = checked
+                        ? [...field.value, CAPABILITY.AVAILABILITY]
+                        : field.value?.filter((v) => v !== CAPABILITY.AVAILABILITY);
+                      field.onChange(updated);
+                    }}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Availability Checking</FormLabel>
+                  <FormDescription>
+                    Booked time is available unless blocked later
+                  </FormDescription>
+                </div>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="capabilities"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start space-y-0 space-x-3">
+                <FormControl>
+                  <Checkbox
+                    checked={field.value?.includes(CAPABILITY.BOOKING)}
+                    onCheckedChange={(checked) => {
+                      const updated = checked
+                        ? [...field.value, CAPABILITY.BOOKING]
+                        : field.value?.filter((v) => v !== CAPABILITY.BOOKING);
+                      field.onChange(updated);
+                    }}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Booking</FormLabel>
+                  <FormDescription>Can add new events to this calendar</FormDescription>
+                </div>
+              </FormItem>
+            )}
+          />
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/app/connections/connections-list.tsx
+++ b/app/connections/connections-list.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { ConnectionListItem } from "./actions";
+
+interface ConnectionsListProps {
+  connections: ConnectionListItem[];
+  onEdit: (connection: ConnectionListItem) => void;
+  onDelete: (id: string) => void;
+  onSetPrimary: (id: string) => void;
+}
+
+export default function ConnectionsList({
+  connections,
+  onEdit,
+  onDelete,
+  onSetPrimary,
+}: ConnectionsListProps) {
+  if (connections.length === 0) {
+    return <p className="text-muted-foreground">No calendar connections yet.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {connections.map((connection) => (
+        <Card key={connection.id}>
+          <CardHeader>
+            <div className="flex items-start justify-between">
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  {connection.displayName}
+                  {connection.isPrimary && <Badge variant="default">Primary</Badge>}
+                </CardTitle>
+                <CardDescription>Provider: {connection.provider}</CardDescription>
+              </div>
+              <div className="flex gap-2">
+                {!connection.isPrimary && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onSetPrimary(connection.id)}
+                  >
+                    Set Primary
+                  </Button>
+                )}
+                <Button variant="outline" size="sm" onClick={() => onEdit(connection)}>
+                  Edit
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => onDelete(connection.id)}
+                >
+                  Delete
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div>
+              <p className="mb-2 text-sm font-medium">Capabilities:</p>
+              <div className="flex flex-wrap gap-2">
+                {connection.capabilities.includes("conflict") && (
+                  <Badge variant="secondary">Conflict Checking</Badge>
+                )}
+                {connection.capabilities.includes("availability") && (
+                  <Badge variant="secondary">Availability Checking</Badge>
+                )}
+                {connection.capabilities.includes("booking") && (
+                  <Badge variant="secondary">Booking</Badge>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/app/connections/provider-select.tsx
+++ b/app/connections/provider-select.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Control } from "react-hook-form";
+
+import type { ProviderType } from "./actions";
+import type { ConnectionFormValues } from "./use-connection-form";
+
+interface ProviderSelectProps {
+  control: Control<ConnectionFormValues>;
+  value: ProviderType;
+  onChange: (provider: ProviderType) => void;
+  disabled?: boolean;
+}
+
+export default function ProviderSelect({
+  control,
+  value,
+  onChange,
+  disabled,
+}: ProviderSelectProps) {
+  return (
+    <FormField
+      control={control}
+      name="provider"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Provider</FormLabel>
+          <Select
+            value={value}
+            onValueChange={(provider: ProviderType) => {
+              field.onChange(provider);
+              onChange(provider);
+            }}
+            disabled={disabled}
+          >
+            <FormControl>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              <SelectItem value="apple">Apple iCloud</SelectItem>
+              <SelectItem value="google">Google Calendar</SelectItem>
+              <SelectItem value="fastmail">Fastmail</SelectItem>
+              <SelectItem value="nextcloud">Nextcloud</SelectItem>
+              <SelectItem value="caldav">Generic CalDAV</SelectItem>
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/app/connections/use-connection-form.ts
+++ b/app/connections/use-connection-form.ts
@@ -1,0 +1,146 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, type UseFormReturn } from "react-hook-form";
+import * as z from "zod";
+
+import { CAPABILITY, type CalendarCapability } from "@/types/constants";
+import type { ProviderType } from "./actions";
+
+const PROVIDER_AUTH_METHODS: Record<ProviderType, "Basic" | "Oauth"> = {
+  apple: "Basic",
+  google: "Oauth",
+  fastmail: "Basic",
+  nextcloud: "Basic",
+  caldav: "Basic",
+};
+
+export const connectionFormSchema = z
+  .object({
+    provider: z.enum(["apple", "google", "fastmail", "nextcloud", "caldav"]),
+    displayName: z.string().min(1, "Display name is required"),
+    authMethod: z.enum(["Basic", "Oauth"]),
+    username: z.string().min(1, "Username is required"),
+    password: z.string().optional(),
+    serverUrl: z.string().optional(),
+    calendarUrl: z.string().optional(),
+    refreshToken: z.string().optional(),
+    clientId: z.string().optional(),
+    clientSecret: z.string().optional(),
+    tokenUrl: z.string().optional(),
+    capabilities: z
+      .array(
+        z.enum([
+          CAPABILITY.CONFLICT,
+          CAPABILITY.AVAILABILITY,
+          CAPABILITY.BOOKING,
+        ]),
+      )
+      .min(1, "Select at least one capability"),
+    isPrimary: z.boolean(),
+  })
+  .refine(
+    (data) => {
+      if (data.authMethod === "Basic") {
+        return !!data.password;
+      }
+      return true;
+    },
+    {
+      message: "Password is required for Basic authentication",
+      path: ["password"],
+    },
+  )
+  .refine(
+    (data) => {
+      if (["nextcloud", "caldav"].includes(data.provider)) {
+        return !!data.serverUrl;
+      }
+      return true;
+    },
+    {
+      message: "Server URL is required for this provider",
+      path: ["serverUrl"],
+    },
+  )
+  .refine(
+    (data) => {
+      if (data.authMethod === "Oauth") {
+        return (
+          !!data.refreshToken &&
+          !!data.clientId &&
+          !!data.clientSecret &&
+          !!data.tokenUrl
+        );
+      }
+      return true;
+    },
+    {
+      message: "All OAuth fields are required",
+      path: ["refreshToken"],
+    },
+  );
+
+export type ConnectionFormValues = z.infer<typeof connectionFormSchema>;
+
+export interface UseConnectionFormReturn {
+  form: UseFormReturn<ConnectionFormValues>;
+  currentProvider: ProviderType;
+  currentAuthMethod: "Basic" | "Oauth";
+  needsServerUrl: boolean;
+  handleProviderChange: (provider: ProviderType) => void;
+}
+
+export function useConnectionForm(): UseConnectionFormReturn {
+  const form = useForm<ConnectionFormValues>({
+    resolver: zodResolver(connectionFormSchema),
+    defaultValues: {
+      provider: "apple",
+      displayName: "",
+      authMethod: "Basic",
+      username: "",
+      password: "",
+      serverUrl: "",
+      calendarUrl: "",
+      refreshToken: "",
+      clientId: "",
+      clientSecret: "",
+      tokenUrl: "https://accounts.google.com/o/oauth2/token",
+      capabilities: [] as CalendarCapability[],
+      isPrimary: false,
+    },
+  });
+
+  const currentProvider = form.watch("provider");
+  const currentAuthMethod = form.watch("authMethod");
+  const needsServerUrl = ["nextcloud", "caldav"].includes(currentProvider);
+
+  const handleProviderChange = (provider: ProviderType) => {
+    const authMethod = PROVIDER_AUTH_METHODS[provider];
+    form.setValue("authMethod", authMethod);
+
+    if (authMethod === "Basic") {
+      form.setValue("refreshToken", "");
+      form.setValue("clientId", "");
+      form.setValue("clientSecret", "");
+      form.setValue("tokenUrl", "");
+    } else {
+      form.setValue("password", "");
+      form.setValue("tokenUrl", "https://accounts.google.com/o/oauth2/token");
+    }
+
+    if (!["nextcloud", "caldav"].includes(provider)) {
+      form.setValue("serverUrl", "");
+    }
+  };
+
+  return {
+    form,
+    currentProvider,
+    currentAuthMethod,
+    needsServerUrl,
+    handleProviderChange,
+  };
+}
+
+export { PROVIDER_AUTH_METHODS };


### PR DESCRIPTION
## Summary
- extract provider select, capabilities, and connection list into their own components
- move form logic into `useConnectionForm`
- keep `ConnectionsClient` focused on composition

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68699c89c804832299358944f9117763