### PR TITLE
Refactor connection actions

### DIFF
--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, beforeAll, beforeEach, it, expect, jest } from '@jest/globals';
+import { CAPABILITY } from '../types/constants';
 
 jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
 jest.mock('tsdav', () => ({
@@ -50,10 +51,10 @@ describe('createConnectionAction validation', () => {
       username: '',
       password: '',
       serverUrl: 'https://x',
-      capabilities: [],
+      capabilities: [CAPABILITY.CONFLICT],
     } as any);
     expect(result.success).toBe(false);
-    expect(result.error).toMatch('Username and password are required');
+    expect(result.error).toMatch('Username is required');
   });
 
   it('requires server URL for caldav provider', async () => {
@@ -63,7 +64,7 @@ describe('createConnectionAction validation', () => {
       authMethod: 'Basic',
       username: 'u',
       password: 'p',
-      capabilities: [],
+      capabilities: [CAPABILITY.CONFLICT],
     } as any);
     expect(result.success).toBe(false);
     expect(result.error).toMatch('Server URL is required');
@@ -79,7 +80,7 @@ describe('createConnectionAction validation', () => {
       clientId: '',
       clientSecret: '',
       tokenUrl: '',
-      capabilities: [],
+      capabilities: [CAPABILITY.CONFLICT],
     } as any);
     expect(result.success).toBe(false);
     expect(result.error).toMatch('All OAuth fields are required');
@@ -95,7 +96,7 @@ describe('createConnectionAction validation', () => {
       clientId: 'c',
       clientSecret: 's',
       tokenUrl: 'https://token',
-      capabilities: [],
+      capabilities: [CAPABILITY.CONFLICT],
     });
     expect(res.success).toBe(true);
     const created = await integrations.listCalendarIntegrations();
@@ -113,13 +114,26 @@ describe('updateConnectionAction', () => {
 
 describe('testConnectionAction validation', () => {
   it('validates Basic auth', async () => {
-    const res = await actions.testConnectionAction('caldav', { authMethod: 'Basic' } as any);
+    const res = await actions.testConnectionAction('caldav', {
+      authMethod: 'Basic',
+      username: '',
+      password: '',
+      capabilities: [CAPABILITY.CONFLICT],
+    } as any);
     expect(res.success).toBe(false);
-    expect(res.error).toMatch('Username and password are required');
+    expect(res.error).toMatch('Username is required');
   });
 
   it('validates OAuth auth', async () => {
-    const res = await actions.testConnectionAction('google', { authMethod: 'Oauth' } as any);
+    const res = await actions.testConnectionAction('google', {
+      authMethod: 'Oauth',
+      username: 'u',
+      refreshToken: '',
+      clientId: '',
+      clientSecret: '',
+      tokenUrl: '',
+      capabilities: [CAPABILITY.CONFLICT],
+    } as any);
     expect(res.success).toBe(false);
     expect(res.error).toMatch('All OAuth fields are required');
   });

--- a/app/connections/actions.ts
+++ b/app/connections/actions.ts
@@ -7,46 +7,26 @@ import {
   listCalendarIntegrations,
   testCalendarConnection,
   updateCalendarIntegration,
-  type BasicAuthConfig,
   type CalendarIntegrationConfig,
   type CreateCalendarIntegrationInput,
-  type OAuthConfig,
   type ProviderType,
   type UpdateCalendarIntegrationInput,
 } from "@/lib/db/integrations";
+import {
+  buildConfigFromValues,
+  mergeConfig,
+} from "@/lib/db/config-utils";
+import {
+  connectionFormSchema,
+  type ConnectionFormValues,
+  connectionConfigSchema,
+} from "@/schemas/connection";
 import { type CalendarCapability } from "@/types/constants";
 import { revalidatePath } from "next/cache";
 
 export type { ProviderType };
 
-export interface BasicAuthFormData {
-  provider: ProviderType;
-  displayName: string;
-  authMethod: "Basic";
-  username: string;
-  password: string;
-  serverUrl?: string;
-  calendarUrl?: string;
-  capabilities: CalendarCapability[];
-  isPrimary?: boolean;
-}
-
-export interface OAuthFormData {
-  provider: ProviderType;
-  displayName: string;
-  authMethod: "Oauth";
-  username: string;
-  refreshToken: string;
-  clientId: string;
-  clientSecret: string;
-  tokenUrl: string;
-  serverUrl?: string;
-  calendarUrl?: string;
-  capabilities: CalendarCapability[];
-  isPrimary?: boolean;
-}
-
-export type ConnectionFormData = BasicAuthFormData | OAuthFormData;
+export type ConnectionFormData = ConnectionFormValues;
 
 export interface ConnectionActionResult<T = undefined> {
   success: boolean;
@@ -71,70 +51,16 @@ export async function createConnectionAction(
   formData: ConnectionFormData,
 ): Promise<ConnectionActionResult<{ id: string; displayName: string }>> {
   try {
-    // Build the config object based on auth method
-    let config: CalendarIntegrationConfig;
-
-    if (formData.authMethod === "Basic") {
-      if (!formData.username || !formData.password) {
-        return {
-          success: false,
-          error: "Username and password are required",
-        };
-      }
-
-      // For providers other than google, apple, fastmail, we need a custom URL
-      if (
-        ["nextcloud", "caldav"].includes(formData.provider) &&
-        !formData.serverUrl
-      ) {
-        return {
-          success: false,
-          error: "Server URL is required for this provider",
-        };
-      }
-
-      config = {
-        authMethod: "Basic",
-        username: formData.username,
-        password: formData.password,
-        serverUrl: formData.serverUrl ?? "",
-        calendarUrl: formData.calendarUrl,
-        capabilities: formData.capabilities,
-      } satisfies BasicAuthConfig;
-    } else if (formData.authMethod === "Oauth") {
-      if (
-        !formData.username ||
-        !formData.refreshToken ||
-        !formData.clientId ||
-        !formData.clientSecret ||
-        !formData.tokenUrl
-      ) {
-        return {
-          success: false,
-          error: "All OAuth fields are required",
-        };
-      }
-
-      config = {
-        authMethod: "Oauth",
-        username: formData.username,
-        refreshToken: formData.refreshToken,
-        clientId: formData.clientId,
-        clientSecret: formData.clientSecret,
-        tokenUrl: formData.tokenUrl,
-        serverUrl: formData.serverUrl ?? "",
-        calendarUrl: formData.calendarUrl,
-        capabilities: formData.capabilities,
-      } satisfies OAuthConfig;
-    } else {
-      return {
-        success: false,
-        error: "Invalid authentication method",
-      };
+    const parsed = connectionFormSchema.safeParse(formData);
+    if (!parsed.success) {
+      return { success: false, error: parsed.error.errors[0]?.message };
     }
 
+    const values = parsed.data;
+    const config = buildConfigFromValues(values);
+
     // Test the connection first
-    const testResult = await testCalendarConnection(formData.provider, config);
+    const testResult = await testCalendarConnection(values.provider, config);
     if (!testResult.success) {
       return {
         success: false,
@@ -144,10 +70,10 @@ export async function createConnectionAction(
 
     // Create the integration
     const input: CreateCalendarIntegrationInput = {
-      provider: formData.provider,
-      displayName: formData.displayName,
+      provider: values.provider,
+      displayName: values.displayName,
       config,
-      isPrimary: formData.isPrimary,
+      isPrimary: values.isPrimary,
     };
 
     const integration = await createCalendarIntegration(input);
@@ -197,67 +123,25 @@ export async function updateConnectionAction(
     }
 
     // Handle config updates
-    const hasConfigUpdates =
-      formData.capabilities !== undefined ||
-      (formData.authMethod === "Basic" &&
-        (formData.serverUrl !== undefined ||
-          formData.username !== undefined ||
-          formData.password !== undefined ||
-          formData.calendarUrl !== undefined)) ||
-      (formData.authMethod === "Oauth" &&
-        (formData.refreshToken !== undefined ||
-          formData.clientId !== undefined ||
-          formData.clientSecret !== undefined));
+    const hasConfigUpdates = Object.keys(formData).some((key) =>
+      [
+        "username",
+        "password",
+        "refreshToken",
+        "clientId",
+        "clientSecret",
+        "tokenUrl",
+        "serverUrl",
+        "calendarUrl",
+        "capabilities",
+      ].includes(key),
+    );
 
     if (hasConfigUpdates) {
-      let config: CalendarIntegrationConfig;
-
-      if (
-        existing.config.authMethod === "Basic" &&
-        formData.authMethod === "Basic"
-      ) {
-        config = {
-          ...existing.config,
-          capabilities: formData.capabilities ?? existing.config.capabilities,
-          serverUrl: formData.serverUrl ?? existing.config.serverUrl,
-          username: formData.username ?? existing.config.username,
-          password: formData.password ?? existing.config.password,
-          calendarUrl: formData.calendarUrl ?? existing.config.calendarUrl,
-        };
-      } else if (
-        existing.config.authMethod === "Oauth" &&
-        formData.authMethod === "Oauth"
-      ) {
-        config = {
-          ...existing.config,
-          capabilities: formData.capabilities ?? existing.config.capabilities,
-          username: formData.username ?? existing.config.username,
-          refreshToken: formData.refreshToken ?? existing.config.refreshToken,
-          clientId: formData.clientId ?? existing.config.clientId,
-          clientSecret: formData.clientSecret ?? existing.config.clientSecret,
-          serverUrl: formData.serverUrl ?? existing.config.serverUrl,
-          calendarUrl: formData.calendarUrl ?? existing.config.calendarUrl,
-        };
-      } else {
-        // Just update capabilities if auth method doesn't match
-        config = {
-          ...existing.config,
-          capabilities: formData.capabilities ?? existing.config.capabilities,
-        };
-      }
-
-      // Test the connection if credentials changed
-      const credentialsChanged =
-        (config.authMethod === "Basic" &&
-          formData.authMethod === "Basic" &&
-          (formData.serverUrl !== undefined ||
-            formData.username !== undefined ||
-            formData.password !== undefined)) ||
-        (config.authMethod === "Oauth" &&
-          formData.authMethod === "Oauth" &&
-          (formData.refreshToken !== undefined ||
-            formData.clientId !== undefined ||
-            formData.clientSecret !== undefined));
+      const { config, credentialsChanged } = mergeConfig(
+        existing.config,
+        formData,
+      );
 
       if (credentialsChanged) {
         const testResult = await testCalendarConnection(
@@ -371,63 +255,17 @@ export async function testConnectionAction(
   config: Partial<ConnectionFormData>,
 ): Promise<ConnectionActionResult<undefined>> {
   try {
-    let testConfig: CalendarIntegrationConfig;
-
-    if (config.authMethod === "Basic") {
-      if (!config.username || !config.password) {
-        return {
-          success: false,
-          error: "Username and password are required",
-        };
-      }
-
-      // Check if server URL is required
-      if (["nextcloud", "caldav"].includes(provider) && !config.serverUrl) {
-        return {
-          success: false,
-          error: "Server URL is required for this provider",
-        };
-      }
-
-      testConfig = {
-        authMethod: "Basic",
-        username: config.username,
-        password: config.password,
-        serverUrl: config.serverUrl ?? "",
-        calendarUrl: config.calendarUrl,
-        capabilities: config.capabilities ?? [],
-      };
-    } else if (config.authMethod === "Oauth") {
-      if (
-        !config.username ||
-        !config.refreshToken ||
-        !config.clientId ||
-        !config.clientSecret ||
-        !config.tokenUrl
-      ) {
-        return {
-          success: false,
-          error: "All OAuth fields are required",
-        };
-      }
-
-      testConfig = {
-        authMethod: "Oauth",
-        username: config.username,
-        refreshToken: config.refreshToken,
-        clientId: config.clientId,
-        clientSecret: config.clientSecret,
-        tokenUrl: config.tokenUrl,
-        serverUrl: config.serverUrl ?? "",
-        calendarUrl: config.calendarUrl,
-        capabilities: config.capabilities ?? [],
-      };
-    } else {
-      return {
-        success: false,
-        error: "Invalid authentication method",
-      };
+    const parsed = connectionConfigSchema.safeParse({
+      provider,
+      ...config,
+      displayName: "",
+      isPrimary: false,
+    });
+    if (!parsed.success) {
+      return { success: false, error: parsed.error.errors[0]?.message };
     }
+
+    const testConfig = buildConfigFromValues(parsed.data);
 
     const result = await testCalendarConnection(provider, testConfig);
 

--- a/app/connections/use-connection-form.ts
+++ b/app/connections/use-connection-form.ts
@@ -2,10 +2,12 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, type UseFormReturn } from "react-hook-form";
-import * as z from "zod";
-
-import { CAPABILITY, type CalendarCapability } from "@/types/constants";
 import type { ProviderType } from "./actions";
+import {
+  connectionFormSchema,
+  type ConnectionFormValues,
+} from "@/schemas/connection";
+import { CAPABILITY, type CalendarCapability } from "@/types/constants";
 
 const PROVIDER_AUTH_METHODS: Record<ProviderType, "Basic" | "Oauth"> = {
   apple: "Basic",
@@ -15,73 +17,7 @@ const PROVIDER_AUTH_METHODS: Record<ProviderType, "Basic" | "Oauth"> = {
   caldav: "Basic",
 };
 
-export const connectionFormSchema = z
-  .object({
-    provider: z.enum(["apple", "google", "fastmail", "nextcloud", "caldav"]),
-    displayName: z.string().min(1, "Display name is required"),
-    authMethod: z.enum(["Basic", "Oauth"]),
-    username: z.string().min(1, "Username is required"),
-    password: z.string().optional(),
-    serverUrl: z.string().optional(),
-    calendarUrl: z.string().optional(),
-    refreshToken: z.string().optional(),
-    clientId: z.string().optional(),
-    clientSecret: z.string().optional(),
-    tokenUrl: z.string().optional(),
-    capabilities: z
-      .array(
-        z.enum([
-          CAPABILITY.CONFLICT,
-          CAPABILITY.AVAILABILITY,
-          CAPABILITY.BOOKING,
-        ]),
-      )
-      .min(1, "Select at least one capability"),
-    isPrimary: z.boolean(),
-  })
-  .refine(
-    (data) => {
-      if (data.authMethod === "Basic") {
-        return !!data.password;
-      }
-      return true;
-    },
-    {
-      message: "Password is required for Basic authentication",
-      path: ["password"],
-    },
-  )
-  .refine(
-    (data) => {
-      if (["nextcloud", "caldav"].includes(data.provider)) {
-        return !!data.serverUrl;
-      }
-      return true;
-    },
-    {
-      message: "Server URL is required for this provider",
-      path: ["serverUrl"],
-    },
-  )
-  .refine(
-    (data) => {
-      if (data.authMethod === "Oauth") {
-        return (
-          !!data.refreshToken &&
-          !!data.clientId &&
-          !!data.clientSecret &&
-          !!data.tokenUrl
-        );
-      }
-      return true;
-    },
-    {
-      message: "All OAuth fields are required",
-      path: ["refreshToken"],
-    },
-  );
-
-export type ConnectionFormValues = z.infer<typeof connectionFormSchema>;
+export { connectionFormSchema, type ConnectionFormValues } from "@/schemas/connection";
 
 export interface UseConnectionFormReturn {
   form: UseFormReturn<ConnectionFormValues>;

--- a/lib/db/config-utils.ts
+++ b/lib/db/config-utils.ts
@@ -1,0 +1,96 @@
+import type { CalendarIntegrationConfig, BasicAuthConfig, OAuthConfig, ProviderType } from "./integrations";
+import type { ConnectionFormValues } from "@/schemas/connection";
+
+/**
+ * Build a CalendarIntegrationConfig from validated form values.
+ */
+export function buildConfigFromValues(values: ConnectionFormValues): CalendarIntegrationConfig {
+  if (values.authMethod === "Basic") {
+    const cfg: BasicAuthConfig = {
+      authMethod: "Basic",
+      username: values.username,
+      password: values.password!,
+      serverUrl: values.serverUrl ?? "",
+      calendarUrl: values.calendarUrl,
+      capabilities: values.capabilities,
+    };
+    return cfg;
+  }
+
+  const cfg: OAuthConfig = {
+    authMethod: "Oauth",
+    username: values.username,
+    refreshToken: values.refreshToken!,
+    clientId: values.clientId!,
+    clientSecret: values.clientSecret!,
+    tokenUrl: values.tokenUrl!,
+    serverUrl: values.serverUrl ?? "",
+    calendarUrl: values.calendarUrl,
+    capabilities: values.capabilities,
+  };
+  return cfg;
+}
+
+/**
+ * Merge an existing CalendarIntegrationConfig with partial form updates.
+ * Returns the merged config along with a flag indicating if credential
+ * fields changed and the connection should be re-tested.
+ */
+export function mergeConfig(
+  existing: CalendarIntegrationConfig,
+  updates: Partial<ConnectionFormValues>,
+): { config: CalendarIntegrationConfig; credentialsChanged: boolean } {
+  let credentialsChanged = false;
+  const result: CalendarIntegrationConfig = { ...existing } as CalendarIntegrationConfig;
+
+  if (existing.authMethod === "Basic") {
+    if (updates.username !== undefined) {
+      credentialsChanged ||= updates.username !== existing.username;
+      result.username = updates.username;
+    }
+    if (updates.password !== undefined) {
+      credentialsChanged ||= updates.password !== existing.password;
+      (result as BasicAuthConfig).password = updates.password;
+    }
+    if (updates.serverUrl !== undefined) {
+      credentialsChanged ||= updates.serverUrl !== existing.serverUrl;
+      result.serverUrl = updates.serverUrl;
+    }
+    if (updates.calendarUrl !== undefined) {
+      result.calendarUrl = updates.calendarUrl;
+    }
+  } else {
+    if (updates.username !== undefined) {
+      credentialsChanged ||= updates.username !== existing.username;
+      result.username = updates.username;
+    }
+    if (updates.refreshToken !== undefined) {
+      credentialsChanged ||= updates.refreshToken !== existing.refreshToken;
+      (result as OAuthConfig).refreshToken = updates.refreshToken;
+    }
+    if (updates.clientId !== undefined) {
+      credentialsChanged ||= updates.clientId !== existing.clientId;
+      (result as OAuthConfig).clientId = updates.clientId;
+    }
+    if (updates.clientSecret !== undefined) {
+      credentialsChanged ||= updates.clientSecret !== existing.clientSecret;
+      (result as OAuthConfig).clientSecret = updates.clientSecret;
+    }
+    if (updates.tokenUrl !== undefined) {
+      (result as OAuthConfig).tokenUrl = updates.tokenUrl;
+    }
+    if (updates.serverUrl !== undefined) {
+      credentialsChanged ||= updates.serverUrl !== existing.serverUrl;
+      result.serverUrl = updates.serverUrl;
+    }
+    if (updates.calendarUrl !== undefined) {
+      result.calendarUrl = updates.calendarUrl;
+    }
+  }
+
+  if (updates.capabilities !== undefined) {
+    result.capabilities = updates.capabilities;
+  }
+
+  return { config: result, credentialsChanged };
+}

--- a/lib/db/integrations.ts
+++ b/lib/db/integrations.ts
@@ -113,10 +113,11 @@ export async function createCalendarIntegration(
         .where(eq(calendarIntegrations.isPrimary, true));
     }
 
-    const [inserted] = tx
+    const inserted = tx
       .insert(calendarIntegrations)
       .values(newIntegration)
-      .returning();
+      .returning()
+      .get();
 
     return inserted;
   });
@@ -240,11 +241,12 @@ export async function updateCalendarIntegration(
         .where(eq(calendarIntegrations.isPrimary, true));
     }
 
-    const [result] = tx
+    const result = tx
       .update(calendarIntegrations)
       .set(updates)
       .where(eq(calendarIntegrations.id, id))
-      .returning();
+      .returning()
+      .get();
 
     return result ?? null;
   });

--- a/schemas/connection.ts
+++ b/schemas/connection.ts
@@ -1,0 +1,90 @@
+import * as z from "zod";
+import { CAPABILITY, type CalendarCapability } from "@/types/constants";
+
+/**
+ * Schema for connection form values used on both client and server.
+ * - isPrimary is optional since server actions may omit it
+ */
+const baseSchema = z.object({
+    provider: z.enum(["apple", "google", "fastmail", "nextcloud", "caldav"]),
+    displayName: z.string().min(1, "Display name is required"),
+    authMethod: z.enum(["Basic", "Oauth"]),
+    username: z.string().min(1, "Username is required"),
+    password: z.string().optional(),
+    serverUrl: z.string().optional(),
+    calendarUrl: z.string().optional(),
+    refreshToken: z.string().optional(),
+    clientId: z.string().optional(),
+    clientSecret: z.string().optional(),
+    tokenUrl: z.string().optional(),
+    capabilities: z
+      .array(
+        z.enum([
+          CAPABILITY.CONFLICT,
+          CAPABILITY.AVAILABILITY,
+          CAPABILITY.BOOKING,
+        ]),
+      )
+      .min(1, "Select at least one capability"),
+    isPrimary: z.boolean().optional().default(false),
+  });
+
+function withValidations<T extends z.ZodTypeAny>(schema: T) {
+  return schema
+    .refine(
+      (data) => {
+        if (data.authMethod === "Basic") {
+          return !!data.password;
+        }
+        return true;
+      },
+      {
+        message: "Password is required for Basic authentication",
+        path: ["password"],
+      },
+    )
+    .refine(
+      (data) => {
+        if (["nextcloud", "caldav"].includes(data.provider)) {
+          return !!data.serverUrl;
+        }
+        return true;
+      },
+      {
+        message: "Server URL is required for this provider",
+        path: ["serverUrl"],
+      },
+    )
+    .refine(
+      (data) => {
+        if (data.authMethod === "Oauth") {
+          return (
+            !!data.refreshToken &&
+            !!data.clientId &&
+            !!data.clientSecret &&
+            !!data.tokenUrl
+          );
+        }
+        return true;
+      },
+      {
+        message: "All OAuth fields are required",
+        path: ["refreshToken"],
+      },
+    );
+}
+
+export const connectionFormSchema = withValidations(baseSchema);
+
+export type ConnectionFormValues = z.infer<typeof connectionFormSchema>;
+
+// Schema for just the connection config (no display name or primary flag)
+export const connectionConfigSchema = withValidations(
+  baseSchema.omit({
+    displayName: true,
+    isPrimary: true,
+  }),
+);
+
+export type ConnectionConfigValues = z.infer<typeof connectionConfigSchema>;
+


### PR DESCRIPTION
## Summary
- centralize connection schemas in `schemas/connection.ts`
- add helpers to build/merge integration configs
- refactor server actions to reuse the schema and helpers
- fix SQLite returning API usage
- update unit tests for new messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869a39b605c8322be6d6bd576feaf2b