### PR TITLE
Add appointments view and patch url.parse

### DIFF
--- a/app/appointments/actions.ts
+++ b/app/appointments/actions.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { getPrimaryCalendarIntegration, createDAVClientFromIntegration } from "@/lib/db/integrations";
+import { createCalDavProvider } from "@/providers/caldav";
+
+export async function listBusyTimesAction(from: string, to: string) {
+  const integration = await getPrimaryCalendarIntegration();
+  if (!integration) return [];
+
+  const client = await createDAVClientFromIntegration(integration);
+  const provider = createCalDavProvider(client, integration.config.calendarUrl ?? "");
+
+  return provider.listBusyTimes({ from, to });
+}

--- a/app/appointments/page.tsx
+++ b/app/appointments/page.tsx
@@ -1,0 +1,30 @@
+import { Calendar } from "@/components/ui/calendar";
+import { listBusyTimesAction } from "./actions";
+import { addDays, startOfDay, format } from "date-fns";
+
+export default async function AppointmentsPage() {
+  const from = startOfDay(new Date());
+  const to = addDays(from, 7);
+
+  const busy = await listBusyTimesAction(format(from, "yyyy-MM-dd'T'HH:mm:ssXXX"), format(to, "yyyy-MM-dd'T'HH:mm:ssXXX"));
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="mb-4 text-3xl font-bold">Appointments</h1>
+      <Calendar
+        mode="single"
+        modifiers={{ busy: busy.map(b => ({ from: new Date(b.startUtc), to: new Date(b.endUtc) })) }}
+        modifiersClassNames={{ busy: "bg-red-200" }}
+      />
+      <div className="mt-6 space-y-2">
+        {busy.length === 0 ? (
+          <p className="text-muted-foreground">No busy times in the next 7 days.</p>
+        ) : (
+          busy.map((b, i) => (
+            <p key={i}>{b.startUtc} - {b.endUtc}</p>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
 import { type NextConfig } from "next";
 
 import "./env.config";
+// Polyfill url.parse to avoid DEP0169 deprecation
+import "./url-polyfill";
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/url-polyfill.ts
+++ b/url-polyfill.ts
@@ -1,0 +1,28 @@
+import { URL } from 'node:url';
+import * as nodeUrl from 'node:url';
+
+const originalParse = nodeUrl.parse;
+
+(nodeUrl as any).parse = function(urlStr: string, parseQueryString?: boolean) {
+  try {
+    const base = urlStr.startsWith('http') ? undefined : 'http://localhost';
+    const u = new URL(urlStr, base);
+    const result: any = {
+      href: u.href,
+      protocol: u.protocol,
+      slashes: true,
+      host: u.host,
+      auth: u.username ? `${u.username}${u.password ? ':' + u.password : ''}` : null,
+      hostname: u.hostname,
+      port: u.port,
+      pathname: u.pathname,
+      search: u.search,
+      query: parseQueryString ? Object.fromEntries(u.searchParams.entries()) : u.search.replace(/^\?/, ''),
+      hash: u.hash,
+      path: u.pathname + u.search,
+    };
+    return result;
+  } catch {
+    return originalParse(urlStr, parseQueryString);
+  }
+};


### PR DESCRIPTION
## Summary
- polyfill `url.parse` with WHATWG `URL` to silence Node v22 deprecation
- expose a new appointments page that lists busy times from the primary calendar
- add server action to fetch busy slots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d7b0830a0832288431f9bc8ab1825