### PR TITLE
Enhance calendar editing workflow

### DIFF
--- a/__tests__/actions.test.ts
+++ b/__tests__/actions.test.ts
@@ -173,3 +173,40 @@ describe('testConnectionAction validation', () => {
     expect(res.success).toBe(true);
   });
 });
+
+describe('connection calendar helpers', () => {
+  it('lists calendars for an existing connection', async () => {
+    const created = await actions.createConnectionAction({
+      provider: 'apple',
+      displayName: 'Apple',
+      authMethod: 'Basic',
+      username: 'u',
+      password: 'p',
+      capabilities: [CAPABILITY.CONFLICT],
+      isPrimary: false,
+    });
+    expect(created.success).toBe(true);
+    const list = await actions.listCalendarsForConnectionAction(
+      created.data!.id,
+    );
+    expect(list.success).toBe(true);
+    expect(list.data).toEqual([
+      { url: 'https://calendar.local/cal1', displayName: 'https://calendar.local/cal1' },
+    ]);
+  });
+
+  it('gets connection details', async () => {
+    const created = await actions.createConnectionAction({
+      provider: 'apple',
+      displayName: 'Apple',
+      authMethod: 'Basic',
+      username: 'u',
+      password: 'p',
+      capabilities: [CAPABILITY.CONFLICT],
+      isPrimary: false,
+    });
+    const details = await actions.getConnectionDetailsAction(created.data!.id);
+    expect(details.success).toBe(true);
+    expect(details.data?.calendarUrl).toBe('https://calendar.local/cal1');
+  });
+});

--- a/app/connections/connections-client.tsx
+++ b/app/connections/connections-client.tsx
@@ -37,6 +37,8 @@ import {
   testConnectionAction,
   updateConnectionAction,
   listCalendarsAction,
+  getConnectionDetailsAction,
+  listCalendarsForConnectionAction,
   type CalendarOption,
   type ConnectionFormData,
   type ConnectionListItem,
@@ -212,8 +214,24 @@ export default function ConnectionsClient({
     }
   };
 
-  const handleEdit = (connection: ConnectionListItem) => {
+  const handleEdit = async (connection: ConnectionListItem) => {
     setEditingConnection(connection);
+    setIsFormOpen(true);
+    setTestStatus({ testing: false });
+
+    const [details, calRes] = await Promise.all([
+      getConnectionDetailsAction(connection.id),
+      listCalendarsForConnectionAction(connection.id),
+    ]);
+
+    if (calRes.success) {
+      setCalendars(calRes.data ?? []);
+    } else {
+      setCalendars([]);
+    }
+
+    const calendarUrl = details.success ? details.data?.calendarUrl ?? "" : "";
+
     form.reset({
       provider: connection.provider as ProviderType,
       displayName: connection.displayName,
@@ -224,15 +242,12 @@ export default function ConnectionsClient({
       username: "",
       password: "",
       serverUrl: "",
-      calendarUrl: "",
+      calendarUrl,
       refreshToken: "",
       clientId: "",
       clientSecret: "",
       tokenUrl: "https://accounts.google.com/o/oauth2/token",
     });
-    setIsFormOpen(true);
-    setTestStatus({ testing: false });
-    setCalendars([]);
   };
 
   const resetForm = () => {


### PR DESCRIPTION
## Summary
- expose helper to fetch calendar details from stored integrations
- expose helper to list calendars from existing connections
- fetch saved calendar data when editing a connection
- test new server helpers

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint . --ext .js,.jsx,.ts,.tsx`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d859ccc1c83228c8b4274bba0826a