### PR TITLE
Implement multi-calendar integration logic

### DIFF
--- a/app/connections/calendar-actions.ts
+++ b/app/connections/calendar-actions.ts
@@ -1,0 +1,104 @@
+"use server";
+
+import {
+  addCalendarToIntegration,
+  getCalendarsForIntegration,
+  updateCalendarCapability,
+  removeCalendar,
+} from "@/lib/db/integrations";
+import { type CalendarCapability } from "@/types/constants";
+import { revalidatePath } from "next/cache";
+import { z } from "zod/v4";
+
+const addCalendarSchema = z.object({
+  integrationId: z.string().uuid(),
+  calendarUrl: z.string().url(),
+  displayName: z.string().min(1),
+  capability: z.enum(["booking", "blocking_available", "blocking_busy"]),
+});
+
+export async function addCalendarAction(
+  integrationId: string,
+  calendarUrl: string,
+  displayName: string,
+  capability: CalendarCapability,
+) {
+  try {
+    const validated = addCalendarSchema.parse({
+      integrationId,
+      calendarUrl,
+      displayName,
+      capability,
+    });
+
+    const result = await addCalendarToIntegration(
+      validated.integrationId,
+      validated.calendarUrl,
+      validated.displayName,
+      validated.capability as CalendarCapability,
+    );
+
+    if (!result.success) {
+      return { success: false, error: result.error.message };
+    }
+
+    revalidatePath("/connections");
+    return { success: true, data: result.data };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to add calendar",
+    };
+  }
+}
+
+export async function updateCalendarCapabilityAction(
+  calendarId: string,
+  capability: CalendarCapability,
+) {
+  try {
+    const result = await updateCalendarCapability(calendarId, capability);
+
+    if (!result.success) {
+      return { success: false, error: result.error.message };
+    }
+
+    revalidatePath("/connections");
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to update calendar",
+    };
+  }
+}
+
+export async function removeCalendarAction(calendarId: string) {
+  try {
+    const result = await removeCalendar(calendarId);
+
+    if (!result.success) {
+      return { success: false, error: result.error.message };
+    }
+
+    revalidatePath("/connections");
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to remove calendar",
+    };
+  }
+}
+
+export async function listCalendarsForIntegrationAction(integrationId: string) {
+  try {
+    const calendars = await getCalendarsForIntegration(integrationId);
+    return { success: true, data: calendars };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to list calendars",
+    };
+  }
+}

--- a/lib/db/config-utils.ts
+++ b/lib/db/config-utils.ts
@@ -11,8 +11,6 @@ export function buildConfigFromValues(values: ConnectionFormValues): CalendarInt
       username: values.username,
       password: values.password!,
       serverUrl: values.serverUrl ?? "",
-      calendarUrl: values.calendarUrl,
-      capabilities: values.capabilities,
     };
     return cfg;
   }
@@ -25,8 +23,6 @@ export function buildConfigFromValues(values: ConnectionFormValues): CalendarInt
     clientSecret: values.clientSecret!,
     tokenUrl: values.tokenUrl!,
     serverUrl: values.serverUrl ?? "",
-    calendarUrl: values.calendarUrl,
-    capabilities: values.capabilities,
   };
   return cfg;
 }
@@ -38,58 +34,49 @@ export function buildConfigFromValues(values: ConnectionFormValues): CalendarInt
  */
 export function mergeConfig(
   existing: CalendarIntegrationConfig,
-  updates: Partial<ConnectionFormValues>,
+  updates: Record<string, unknown>,
 ): { config: CalendarIntegrationConfig; credentialsChanged: boolean } {
   let credentialsChanged = false;
   const result: CalendarIntegrationConfig = { ...existing } as CalendarIntegrationConfig;
+  const u = updates as any;
 
   if (existing.authMethod === "Basic") {
-    if (updates.username !== undefined) {
-      credentialsChanged ||= updates.username !== existing.username;
-      result.username = updates.username;
+    if (u.username !== undefined) {
+      credentialsChanged ||= u.username !== existing.username;
+      result.username = u.username;
     }
-    if (updates.password !== undefined) {
-      credentialsChanged ||= updates.password !== existing.password;
-      (result as BasicAuthConfig).password = updates.password;
+    if (u.password !== undefined) {
+      credentialsChanged ||= u.password !== existing.password;
+      (result as BasicAuthConfig).password = u.password;
     }
-    if (updates.serverUrl !== undefined) {
-      credentialsChanged ||= updates.serverUrl !== existing.serverUrl;
-      result.serverUrl = updates.serverUrl;
-    }
-    if (updates.calendarUrl !== undefined) {
-      result.calendarUrl = updates.calendarUrl;
+    if (u.serverUrl !== undefined) {
+      credentialsChanged ||= u.serverUrl !== existing.serverUrl;
+      result.serverUrl = u.serverUrl;
     }
   } else {
-    if (updates.username !== undefined) {
-      credentialsChanged ||= updates.username !== existing.username;
-      result.username = updates.username;
+    if (u.username !== undefined) {
+      credentialsChanged ||= u.username !== existing.username;
+      result.username = u.username;
     }
-    if (updates.refreshToken !== undefined) {
-      credentialsChanged ||= updates.refreshToken !== existing.refreshToken;
-      (result as OAuthConfig).refreshToken = updates.refreshToken;
+    if (u.refreshToken !== undefined) {
+      credentialsChanged ||= u.refreshToken !== existing.refreshToken;
+      (result as OAuthConfig).refreshToken = u.refreshToken;
     }
-    if (updates.clientId !== undefined) {
-      credentialsChanged ||= updates.clientId !== existing.clientId;
-      (result as OAuthConfig).clientId = updates.clientId;
+    if (u.clientId !== undefined) {
+      credentialsChanged ||= u.clientId !== existing.clientId;
+      (result as OAuthConfig).clientId = u.clientId;
     }
-    if (updates.clientSecret !== undefined) {
-      credentialsChanged ||= updates.clientSecret !== existing.clientSecret;
-      (result as OAuthConfig).clientSecret = updates.clientSecret;
+    if (u.clientSecret !== undefined) {
+      credentialsChanged ||= u.clientSecret !== existing.clientSecret;
+      (result as OAuthConfig).clientSecret = u.clientSecret;
     }
-    if (updates.tokenUrl !== undefined) {
-      (result as OAuthConfig).tokenUrl = updates.tokenUrl;
+    if (u.tokenUrl !== undefined) {
+      (result as OAuthConfig).tokenUrl = u.tokenUrl;
     }
-    if (updates.serverUrl !== undefined) {
-      credentialsChanged ||= updates.serverUrl !== existing.serverUrl;
-      result.serverUrl = updates.serverUrl;
+    if (u.serverUrl !== undefined) {
+      credentialsChanged ||= u.serverUrl !== existing.serverUrl;
+      result.serverUrl = u.serverUrl;
     }
-    if (updates.calendarUrl !== undefined) {
-      result.calendarUrl = updates.calendarUrl;
-    }
-  }
-
-  if (updates.capabilities !== undefined) {
-    result.capabilities = updates.capabilities;
   }
 
   return { config: result, credentialsChanged };

--- a/lib/db/encryption.ts
+++ b/lib/db/encryption.ts
@@ -34,12 +34,12 @@ export function encrypt(text: string): Result<string, EncryptionError> {
 
     return ok(result);
   } catch (error) {
-    return err(
+    return err<EncryptionError>(
       new EncryptionError(
         error instanceof Error ? error.message : "Encryption failed",
         "ENCRYPT_FAILED",
       ),
-    );
+    ) as Result<string, EncryptionError>;
   }
 }
 
@@ -67,11 +67,11 @@ export function decrypt(encryptedText: string): Result<string, EncryptionError> 
 
     return ok(decrypted.toString("utf8"));
   } catch (error) {
-    return err(
+    return err<EncryptionError>(
       new EncryptionError(
         error instanceof Error ? error.message : "Decryption failed",
         "DECRYPT_FAILED",
       ),
-    );
+    ) as Result<string, EncryptionError>;
   }
 }

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -9,7 +9,7 @@ function initDb() {
 
   // Create database connection
   const sqlite = new Database("scheduler.db");
-  const db = drizzle(sqlite, { schema });
+  const db = drizzle(sqlite);
 
   try {
     createTables(db);


### PR DESCRIPTION
## Summary
- add calendar management functions to integration DB layer
- implement server actions for manipulating calendars
- support encryption errors with Result return types

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property errors and type issues)*
- `npx eslint . --ext .js,.jsx,.ts,.tsx` *(fails: lint errors)*
- `npm test --silent` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d9dfc72a88322b4bbf5a159622899